### PR TITLE
Security Patches :D

### DIFF
--- a/hal/acdb.h
+++ b/hal/acdb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2020, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2021, The Linux Foundation. All rights reserved.
  * Not a Contribution.
  *
  * Copyright (C) 2013 The Android Open Source Project
@@ -41,7 +41,7 @@ enum {
 
 struct mixer;
 /* Audio calibration related functions */
-typedef void (*acdb_deallocate_t)();
+typedef void (*acdb_deallocate_t)(void);
 typedef int  (*acdb_init_t)();
 typedef int  (*acdb_init_v2_t)(const char *, char *, int);
 typedef int  (*acdb_init_v3_t)(const char *, char *, struct listnode *);

--- a/hal/audio_extn/a2dp.c
+++ b/hal/audio_extn/a2dp.c
@@ -155,7 +155,7 @@
 static void *vndk_fwk_lib_handle = NULL;
 static int is_running_with_enhanced_fwk = UNINITIALIZED;
 
-typedef int (*vndk_fwk_isVendorEnhancedFwk_t)();
+typedef int (*vndk_fwk_isVendorEnhancedFwk_t)(void);
 static vndk_fwk_isVendorEnhancedFwk_t vndk_fwk_isVendorEnhancedFwk;
 
 /*

--- a/hal/audio_extn/audio_extn.c
+++ b/hal/audio_extn/audio_extn.c
@@ -5554,10 +5554,10 @@ static void *batt_listener_lib_handle = NULL;
 typedef void (*batt_listener_init_t)(battery_status_change_fn_t);
 static batt_listener_init_t batt_listener_init;
 
-typedef void (*batt_listener_deinit_t)();
+typedef void (*batt_listener_deinit_t)(void);
 static batt_listener_deinit_t batt_listener_deinit;
 
-typedef bool (*batt_prop_is_charging_t)();
+typedef bool (*batt_prop_is_charging_t)(void);
 static batt_prop_is_charging_t batt_prop_is_charging;
 
 void battery_listener_feature_init(bool is_feature_enabled)

--- a/hal/audio_extn/battery_listener.h
+++ b/hal/audio_extn/battery_listener.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2019, The Linux Foundation. All rights reserved.
+* Copyright (c) 2019, 2021 The Linux Foundation. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are
@@ -31,8 +31,8 @@ extern "C" {
 #endif
 typedef void (* battery_status_change_fn_t)(bool);
 void battery_properties_listener_init(battery_status_change_fn_t fn);
-void battery_properties_listener_deinit();
-bool battery_properties_is_charging();
+void battery_properties_listener_deinit(void);
+bool battery_properties_is_charging(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
CFI check is failing due to difference in
function signature during CVE-2019-10581
POC test. Fix the issue by matching the
function signature in header file and
function pointer type.

Change-Id: I92ccb0871b09f5757195844984519d51367ed35f