### PR TITLE
Security Patches :D

### DIFF
--- a/hal/acdb.h
+++ b/hal/acdb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013-2018, 2021 The Linux Foundation. All rights reserved.
  * Not a Contribution.
  *
  * Copyright (C) 2013 The Android Open Source Project
@@ -43,7 +43,7 @@ enum {
 
 struct mixer;
 /* Audio calibration related functions */
-typedef void (*acdb_deallocate_t)();
+typedef void (*acdb_deallocate_t)(void);
 typedef int  (*acdb_init_t)();
 typedef int  (*acdb_init_v2_t)(const char *, char *, int);
 typedef int  (*acdb_init_v3_t)(const char *, char *, struct listnode *);

--- a/hal/audio_extn/battery_listener.h
+++ b/hal/audio_extn/battery_listener.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2018, The Linux Foundation. All rights reserved.
+* Copyright (c) 2018, 2021 The Linux Foundation. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions are
@@ -32,8 +32,8 @@ extern "C" {
 #endif
 typedef void (* battery_status_change_fn_t)(bool);
 void audio_extn_battery_properties_listener_init(battery_status_change_fn_t fn);
-void audio_extn_battery_properties_listener_deinit();
-bool audio_extn_battery_properties_is_charging();
+void audio_extn_battery_properties_listener_deinit(void);
+bool audio_extn_battery_properties_is_charging(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
CFI check is failing due to difference in
function signature during CVE-2019-10581
POC test. Fix the issue by matching the
function signature in header file and
function pointer type.

Change-Id: I92ccb0871b09f5757195844984519d51367ed35f