### PR TITLE
Security Patches :D

### DIFF
--- a/hal/acdb.h
+++ b/hal/acdb.h
@@ -26,7 +26,7 @@
 #define ACDB_METAINFO_KEY_MODULE_NAME_LEN 100
 
 /* Audio calibration related functions */
-typedef void (*acdb_deallocate_t)();
+typedef void (*acdb_deallocate_t)(void);
 typedef int  (*acdb_init_v3_t)(const char *, char *, struct listnode *);
 typedef int  (*acdb_init_v2_cvd_t)(char *, char *, int);
 typedef int  (*acdb_init_v2_t)(char *);


### PR DESCRIPTION
CFI check is failing due to difference in
function signature during CVE-2019-10581
POC test. Fix the issue by matching the
function signature in header file and
function pointer type.

Change-Id: I92ccb0871b09f5757195844984519d51367ed35f